### PR TITLE
Handle cases where scenarios did not contain one or more scenario types

### DIFF
--- a/src/job_worker/handler_helpers.jl
+++ b/src/job_worker/handler_helpers.jl
@@ -446,7 +446,7 @@ end
 Generate all registered visualizations for the result set
 """
 function generate_all_visualizations(
-    scenarios_df::DataFrame,
+    scenario_spec::DataFrame,
     result_set::ADRIA.ResultSet,
     upload_directory_path::String
 )
@@ -465,7 +465,7 @@ function generate_all_visualizations(
 
             # Generate the plot
             vega_plot = plot_adria_scenarios(
-                scenarios_df,
+                scenario_spec,
                 result_set,
                 metric_data;
                 title=metric.title,

--- a/src/job_worker/handler_helpers.jl
+++ b/src/job_worker/handler_helpers.jl
@@ -283,7 +283,7 @@ struct MetricFunction
     name::String
     title::String
     y_label::String
-    func::Function
+    func::Union{Function,ADRIA.metrics.Metric}
     description::String
 end
 
@@ -299,7 +299,7 @@ function register_metric!(
     name::String,
     title::String,
     y_label::String,
-    func::Function,
+    func::Union{Function,ADRIA.metrics.Metric},
     description::String=""
 )
     metric = MetricFunction(name, title, y_label, func, description)
@@ -332,13 +332,6 @@ end
 # =====================================================
 
 """
-Convert ADRIA metric objects to callable functions
-"""
-function metric_to_function(metric_obj)::Function
-    return (result_set) -> metric_obj(result_set)
-end
-
-"""
 Initialize the default set of metric functions using only available ADRIA metrics
 """
 function initialize_default_metrics!()
@@ -350,7 +343,7 @@ function initialize_default_metrics!()
         "relative_cover",
         "Relative Coral Cover Over Time",
         "Relative Cover",
-        metric_to_function(ADRIA.metrics.scenario_relative_cover),
+        ADRIA.metrics.scenario_relative_cover,
         "Shows the relative coral cover across scenarios over time"
     )
 
@@ -359,7 +352,7 @@ function initialize_default_metrics!()
         "total_absolute_cover",
         "Total Absolute Coral Cover Over Time",
         "Total Cover (m²)",
-        metric_to_function(ADRIA.metrics.scenario_total_cover),
+        ADRIA.metrics.scenario_total_cover,
         "Shows the absolute total coral cover across scenarios"
     )
 
@@ -368,7 +361,7 @@ function initialize_default_metrics!()
         "relative_shelter_volume",
         "Relative Shelter Volume Over Time",
         "Relative Shelter Volume",
-        metric_to_function(ADRIA.metrics.scenario_rsv),
+        ADRIA.metrics.scenario_rsv,
         "Shows the shelter volume relative to theoretical maximum"
     )
 
@@ -377,7 +370,7 @@ function initialize_default_metrics!()
         "absolute_shelter_volume",
         "Absolute Shelter Volume Over Time",
         "Shelter Volume (m³)",
-        metric_to_function(ADRIA.metrics.scenario_asv),
+        ADRIA.metrics.scenario_asv,
         "Shows the total shelter volume provided by corals"
     )
 
@@ -386,7 +379,7 @@ function initialize_default_metrics!()
         "relative_juveniles",
         "Relative Juvenile Population Over Time",
         "Relative Juveniles",
-        metric_to_function(ADRIA.metrics.scenario_relative_juveniles),
+        ADRIA.metrics.scenario_relative_juveniles,
         "Shows the relative juvenile coral population across scenarios"
     )
 
@@ -395,7 +388,7 @@ function initialize_default_metrics!()
         "absolute_juveniles",
         "Absolute Juvenile Population Over Time",
         "Juvenile Cover (m²)",
-        metric_to_function(ADRIA.metrics.scenario_absolute_juveniles),
+        ADRIA.metrics.scenario_absolute_juveniles,
         "Shows the absolute juvenile coral cover across scenarios"
     )
 
@@ -404,7 +397,7 @@ function initialize_default_metrics!()
         "coral_evenness",
         "Coral Evenness Over Time",
         "Evenness Index",
-        metric_to_function(ADRIA.metrics.scenario_evenness),
+        ADRIA.metrics.scenario_evenness,
         "Shows the evenness of coral species distribution (Simpson's diversity)"
     )
 
@@ -413,7 +406,7 @@ function initialize_default_metrics!()
         "juvenile_indicator",
         "Juvenile Density Indicator Over Time",
         "Density Indicator",
-        metric_to_function(ADRIA.metrics.scenario_juvenile_indicator),
+        ADRIA.metrics.scenario_juvenile_indicator,
         "Shows juvenile density relative to theoretical maximum (0-1 scale)"
     )
 
@@ -424,7 +417,7 @@ function initialize_default_metrics!()
     #     "condition_index",
     #     "Reef Condition Index",
     #     "Condition Index",
-    #     metric_to_function(ADRIA.metrics.scenario_rci),
+    #     ADRIA.metrics.scenario_rci,
     #     "Reef condition index"
     # )
 
@@ -433,7 +426,7 @@ function initialize_default_metrics!()
     #     "tourism_index",
     #     "Reef Tourism Index",
     #     "Tourism Index",
-    #     metric_to_function(ADRIA.metrics.scenario_rti),
+    #     ADRIA.metrics.scenario_rti,
     #     "Reef tourism index"
     # )
 
@@ -442,7 +435,7 @@ function initialize_default_metrics!()
     #     "fisheries_index",
     #     "Reef Fisheries Index",
     #     "Fisheries Index",
-    #     metric_to_function(ADRIA.metrics.scenario_rfi),
+    #     ADRIA.metrics.scenario_rfi,
     #     "Reef fisheries index"
     # )
 

--- a/src/processing/processing.jl
+++ b/src/processing/processing.jl
@@ -17,14 +17,13 @@ const DATAPACKAGE_MODE = DatapackageMode()
 const RME_MODE = RMEMode()
 
 """
-    extract_location_scenario_data(result_set, scenarios_df)
+    extract_location_scenario_data(result_set)
 
 Efficiently extract and aggregate timestep, scenario type, and relative cover data from ADRIA results.
 Aggregates by scenario_type (guided, unguided, counterfactual) instead of individual scenarios.
 
 # Arguments
 - `result_set`: ADRIA ResultSet containing the relative_cover metric
-- `scenarios_df`: DataFrame containing scenario specifications with scenario type information
 
 # Returns
 DataFrame with columns:
@@ -39,15 +38,16 @@ DataFrame with columns:
 
 # Example
 ```julia
-tidy_data = extract_location_scenario_data(result_set, scenarios_df)
+tidy_data = extract_location_scenario_data(result_set)
 ```
 """
-function extract_location_scenario_data(result_set, scenarios_df)
+function extract_location_scenario_data(result_set)
+    # @here
     # Extract 3D relative cover data (timesteps × locations × scenarios)
     relative_cover_data = ADRIA.relative_cover(result_set)
 
     # Get scenario type groupings from ADRIA analysis
-    scenario_groups = ADRIA.analysis.scenario_types(scenarios_df)
+    scenario_groups = ADRIA.analysis.scenario_types(result_set.inputs)
 
     """
     Map scenario ID to its corresponding scenario type.
@@ -363,7 +363,7 @@ function export_adria_web_data(result_set, scenarios_df, datapackage_path;
         # Step 1: Convert ADRIA results to tidy format aggregated by scenario type
         @info "Converting to tidy data format..."
         step_start = time()
-        tidy_data = extract_location_scenario_data(result_set, scenarios_df)
+        tidy_data = extract_location_scenario_data(result_set)
         step_duration = time() - step_start
         @info "✓ Tidy data created in $(round(step_duration, digits=2)) seconds" nrows = nrow(
             tidy_data

--- a/src/processing/processing.jl
+++ b/src/processing/processing.jl
@@ -59,15 +59,21 @@ function extract_location_scenario_data(result_set)
     String indicating scenario type: "guided", "unguided", "counterfactual", or "unknown"
     """
     function scenario_id_to_type(scenario_id::Int)
-        if scenario_groups[:guided][scenario_id] == 1
-            return "guided"
-        elseif scenario_groups[:unguided][scenario_id] == 1
-            return "unguided"
-        elseif scenario_groups[:counterfactual][scenario_id] == 1
-            return "counterfactual"
+        for stype in ADRIA.analysis.SCENARIO_TYPES
+            # Only handle relevant scenario types for provided result set
+            if stype in keys(scenario_groups)
+                if scenario_groups[stype][scenario_id] == 1
+                    return String(stype)
+                end
+            end
         end
+
         return "unknown"
     end
+
+    # TODO: Investigate use of ADRIA provided location-based metric
+    # Suspect it will be much more performant than interacting with a DataFrame
+    # ADRIA.metrics.loc_trajectory(mean, relative_cover_data)
 
     # Convert 3D array to long-format DataFrame using stack()
     df = DataFrame(stack(relative_cover_data))


### PR DESCRIPTION
Key/index not found error raised when the scenarios run did not include one or more scenario types.

e.g., where the sample size was so small that "unguided" scenarios were never run.

Previously it was assumed that a scenario set included all scenario types.